### PR TITLE
ci: use GitHub Actions

### DIFF
--- a/.github/workflows/addToAPMProject.yml
+++ b/.github/workflows/addToAPMProject.yml
@@ -1,0 +1,51 @@
+name: Add to APM Project
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  add_to_project:
+    runs-on: ubuntu-latest
+    name: Assign issues to APM Project for the Server Team
+    steps:
+      - uses: octokit/graphql-action@v2.x
+        id: add_to_project
+        with:
+          query: |
+            mutation add_to_project($projectid:ID!,$contentid:ID!) {
+              addProjectV2ItemById(input:{projectId:$projectid contentId:$contentid}) {
+                item {
+                  ... on ProjectV2Item {
+                    id
+                  }
+                }
+              }
+            }
+          projectid: ${{ env.PROJECT_ID }}
+          contentid: ${{ github.event.issue.node_id }}
+        env:
+          PROJECT_ID: "PVT_kwDOAGc3Zs0VSg"
+          GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+      - uses: octokit/graphql-action@v2.x
+        id: label_team
+        with:
+          query: |
+            mutation label_team($projectid:ID!,$itemid:ID!,$fieldid:ID!,$value:String!) {
+              updateProjectV2ItemFieldValue(input: { projectId:$projectid itemId:$itemid fieldId:$fieldid value:{singleSelectOptionId: $value} }) {
+                projectV2Item {
+                  id
+                  content {
+                    ... on Issue {
+                      number
+                    }
+                  }
+                }
+              }
+            }
+          projectid: ${{ env.PROJECT_ID }}
+          itemid: ${{ fromJSON(steps.add_to_project.outputs.data).addProjectV2ItemById.item.id }}
+          fieldid: "PVTSSF_lADOAGc3Zs0VSs2scg"
+          value: "6c538d8a"
+        env:
+          PROJECT_ID: "PVT_kwDOAGc3Zs0VSg"
+          GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: ci
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+
+# limit the access of the generated GITHUB_TOKEN
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [oldstable, stable]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+          cache-dependency-path: '**/go.sum'
+      - name: Unit tests
+        run: go test -v ./...


### PR DESCRIPTION
This repo needs almost no care or feeding, so keep it simple by using GitHub Actions for CI.