### PR TITLE
fix: add support types.Alias

### DIFF
--- a/cmd/generate-fastjson/main.go
+++ b/cmd/generate-fastjson/main.go
@@ -274,6 +274,9 @@ if err := %s.%s(w); err != nil && firstErr == nil {
 		generateInterfaceValue(w, expr, t)
 	case *types.Struct:
 		generateStructValue(w, expr, t)
+	case *types.Alias:
+		unaliasType := types.Unalias(t)
+		generateValue(w, expr, unaliasType)
 	default:
 		panic(fmt.Errorf("unhandled type %T", t))
 	}
@@ -394,6 +397,9 @@ func isNonZero(expr string, t types.Type) string {
 		default:
 			zero = "0"
 		}
+	case *types.Alias:
+		unaliasType := types.Unalias(t)
+		isNonZero(expr, unaliasType)
 	default:
 		panic(fmt.Errorf("unhandled type %T", t))
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module go.elastic.co/fastjson
 
-go 1.22
+go 1.23
 
-require golang.org/x/tools v0.24.0
+require golang.org/x/tools v0.30.0
 
 require (
-	golang.org/x/mod v0.20.0 // indirect
-	golang.org/x/sync v0.8.0 // indirect
+	golang.org/x/mod v0.23.0 // indirect
+	golang.org/x/sync v0.11.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
-golang.org/x/mod v0.20.0 h1:utOm6MM3R3dnawAiJgn0y+xvuYRsm1RKM/4giyfDgV0=
-golang.org/x/mod v0.20.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
-golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
-golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
-golang.org/x/tools v0.24.0 h1:J1shsA93PJUEVaUSaay7UXAyE8aimq3GW0pjlolpa24=
-golang.org/x/tools v0.24.0/go.mod h1:YhNqVBIfWHdzvTLs0d8LCuMhkKUgSUKldakyV7W/WDQ=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/mod v0.23.0 h1:Zb7khfcRGKk+kqfxFaP5tZqCnDZMjC5VtUBs87Hr6QM=
+golang.org/x/mod v0.23.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
+golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
+golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/tools v0.30.0 h1:BgcpHewrV5AUp2G9MebG4XPFI1E2W41zU1SaqVA9vJY=
+golang.org/x/tools v0.30.0/go.mod h1:c347cR/OJfw5TI+GfX7RUPNMdDRRbjvYTS0jPyvsVtY=


### PR DESCRIPTION
## ❓ Why is this being changed

generating on newer versions of go is failing with

panic: unhandled type *types.Alias
 
## 🧑‍💻 What is being changed


add types alias case

Related to https://github.com/elastic/apm-data/pull/443
 
 