### PR TITLE
fix: do not marshal NaN and Inf float values

### DIFF
--- a/cmd/generate-fastjson/main.go
+++ b/cmd/generate-fastjson/main.go
@@ -91,7 +91,15 @@ func main() {
 package %s
 
 import (
+	"errors"
+	"math"
+
 	%q
+)
+
+var (
+	_ = errors.New
+	_ = math.IsNaN
 )
 `[1:], pkg.Types.Name(), fastjsonPath)
 
@@ -314,8 +322,24 @@ func generateBasicValue(w *bytes.Buffer, expr string, exprType *types.Basic) {
 		method = "Uint64"
 	case types.Float32:
 		method = "Float32"
+		fmt.Fprintf(w, `
+if math.IsNaN(float64(%s)) {
+	return errors.New("json: '%s': unsupported value: NaN")
+}
+if math.IsInf(float64(%s), 0) {
+	return errors.New("json: '%s': unsupported value: Inf")
+}
+`[1:], expr, expr, expr, expr)
 	case types.Float64:
 		method = "Float64"
+		fmt.Fprintf(w, `
+if math.IsNaN(%s) {
+	return errors.New("json: '%s': unsupported value: NaN")
+}
+if math.IsInf(%s, 0) {
+	return errors.New("json: '%s': unsupported value: Inf")
+}
+`[1:], expr, expr, expr, expr)
 	case types.String:
 		method = "String"
 	default:

--- a/marshaler.go
+++ b/marshaler.go
@@ -16,7 +16,9 @@ package fastjson
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"math"
 )
 
 // Marshaler defines an interface that types can implement to provide
@@ -87,8 +89,20 @@ func Marshal(w *Writer, v interface{}) error {
 	case int64:
 		w.Int64(v)
 	case float32:
+		if math.IsNaN(float64(v)) {
+			return errors.New("json: unsupported value: NaN")
+		}
+		if math.IsInf(float64(v), 0) {
+			return errors.New("json: unsupported value: Inf")
+		}
 		w.Float32(v)
 	case float64:
+		if math.IsNaN(v) {
+			return errors.New("json: unsupported value: NaN")
+		}
+		if math.IsInf(v, 0) {
+			return errors.New("json: unsupported value: Inf")
+		}
 		w.Float64(v)
 	case bool:
 		w.Bool(v)

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -3,6 +3,7 @@ package fastjson
 import (
 	"encoding/json"
 	"errors"
+	"math"
 	"reflect"
 	"testing"
 )
@@ -40,6 +41,30 @@ func TestMarshal(t *testing.T) {
 	mustUnmarshal(w.Bytes(), &fastjsonDecoded)
 	if !reflect.DeepEqual(stdlibDecoded, fastjsonDecoded) {
 		t.Fatal("different encoding")
+	}
+}
+
+func TestMarshalError(t *testing.T) {
+	m := map[string]interface{}{
+		"nan-float32":  float32(math.NaN()),
+		"nan-float64":  float64(math.NaN()),
+		"-inf-float32": float32(math.Inf(-1)),
+		"-inf-float64": float32(math.Inf(-1)),
+		"+inf-float32": float32(math.Inf(+1)),
+		"+inf-float64": float32(math.Inf(+1)),
+	}
+
+	for k, v := range m {
+		_, stdlibErr := json.Marshal(v)
+		if stdlibErr == nil {
+			t.Errorf("%s: expected stdlib err: %v", k, stdlibErr)
+		}
+
+		var w Writer
+		err := Marshal(&w, v)
+		if err == nil {
+			t.Errorf("%s: expected fastjson err: %v", k, err)
+		}
 	}
 }
 

--- a/writer.go
+++ b/writer.go
@@ -15,7 +15,6 @@
 package fastjson
 
 import (
-	"math"
 	"strconv"
 	"time"
 	"unicode/utf8"
@@ -82,10 +81,6 @@ func (w *Writer) Float32(n float32) {
 
 // Float64 appends n to the buffer.
 func (w *Writer) Float64(n float64) {
-	if math.IsNaN(n) || math.IsInf(n, 0) {
-		w.buf = append(w.buf, '0')
-		return
-	}
 	w.buf = strconv.AppendFloat(w.buf, float64(n), 'g', -1, 64)
 }
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -95,7 +95,7 @@ func BenchmarkFloat(b *testing.B) {
 	b.Run("string", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			w.Reset()
-			w.Float64(3.14 + float64(i))
+			Marshal(&w, 3.14+float64(i))
 		}
 	})
 }


### PR DESCRIPTION
NaN and Inf are not valid float values in json
the Go stdlib does not allow to marshal them and return an error.

fastjson does not return an error so the only option (besides panic) is to treat them as 0.
Users of this library should validate they are properly handling NaN/Inf float values if necessary